### PR TITLE
removed stack trace appending to log messgae

### DIFF
--- a/src/main/java/com/logentries/logback/LogentriesAppender.java
+++ b/src/main/java/com/logentries/logback/LogentriesAppender.java
@@ -233,13 +233,6 @@ public class LogentriesAppender extends AppenderBase<ILoggingEvent> {
 	protected void append(ILoggingEvent event) {
 		// Render the event according to layout
 		String formattedEvent = layout.doLayout(event);
-
-		// Append stack trace if present
-		IThrowableProxy error = event.getThrowableProxy();
-		if (error != null) {
-			formattedEvent += ExceptionFormatter.formatException(error);
-		}
-
 		// Prepare to be queued
 		this.le_async.addLineToQueue(formattedEvent);
 	}


### PR DESCRIPTION
Removed this due to duplication of stack traces. The if loop removed in append was causing stack traces to print twice.
@vilda 